### PR TITLE
ATM-65 Refactored: Making a simpler Styleguide

### DIFF
--- a/src/pages/styleguide/index.astro
+++ b/src/pages/styleguide/index.astro
@@ -1,0 +1,37 @@
+---
+import {colors, fontFamily} from '../../styles/themes/base'
+---
+<>
+    <div class="w-11/12 m-auto mb-5">
+        <h1 class="text-center text-4xl">The Astoria Tech Meetup Styleguide</h1>
+        <p class="text-center mt-2">A guide for contributors for element styling.  It is always evolving.</p>
+    </div>
+    <div class="w-11/12 m-auto mx-5">
+        <h2 class="text-center text-2xl">Theme Colors</h2>
+        <div>
+            <h3 class="text-xl">Themes: Default</h3>
+            <p>The goal with theming is to have a set of standard colors that can be used in light or dark mode for any element. Contributors should feel confident to add, modify, or delete themes when they want to change the look of the site with ease. This theme is the default theme, which should be used as a starting point for any additional themes.</p>
+            <ul>
+                {Object.entries(colors).map(itemArr => (
+                    <li>
+                        <span class="font-bold">{itemArr[0]}:</span>{itemArr[1]}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    </div>
+    <div class="w-11/12 m-auto mx-5">
+        <h2 class="text-center text-2xl">Typography</h2>
+        <div>
+            <h3 class="text-xl">Typography: Font Families</h3>
+            <p>These are the current font families available for use.  Noto Sans is the default font for this site unless otherwise stated.</p>
+            <ul>
+                {Object.entries(fontFamily).map(itemArr => (
+                    <li>
+                        <span class="font-bold">{itemArr[0]}:</span>{itemArr[1]}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    </div>
+</>

--- a/src/pages/styleguide/index.astro
+++ b/src/pages/styleguide/index.astro
@@ -3,25 +3,32 @@ import {colors, fontFamily} from '../../styles/themes/base'
 ---
 
 <>
-  <div class="w-11/12 m-auto mb-5">
-    <h1 class="text-center text-4xl">The Astoria Tech Meetup Styleguide</h1>
-    <p class="text-center mt-2">A guide for contributors for element styling. It is always evolving.</p>
+  <div class="w-11/12 m-auto">
+    <h1 class="text-center text-6xl font-bold">The Astoria Tech Meetup Styleguide</h1>
+    <h2 class="text-center mt-2 text-2xl">A guide for contributors for element styling. It is always evolving.</h2>
   </div>
-  <div class="w-11/12 m-auto mx-5">
-    <h2 class="text-center text-2xl">Theme Colors</h2>
+  <div class="w-11/12 m-auto mt-10">
+    <h2 class="text-center text-3xl font-bold">Theme Colors</h2>
     <div>
-      <h3 class="text-xl">Themes: Default</h3>
+      <h3 class="text-xl mb-1">
+        <span class="font-bold">Themes:</span> Default
+      </h3>
       <p>
         The goal with theming is to have a set of standard colors that can be used in light or dark mode for any
         element. Contributors should feel confident to add, modify, or delete themes when they want to change the look
         of the site with ease. This theme is the default theme, which should be used as a starting point for any
         additional themes.
       </p>
-      <ul>
+      <ul
+        class="mt-5 w-full flex flex-nowrap flex-col justify-center content-between border-2 border-black border-solid"
+      >
         {
           Object.entries(colors).map(itemArr => (
-            <li>
-              <span class="font-bold">{itemArr[0]}:</span>
+            <li
+              class="w-full h-[50px] [&:not(:last-child)]:border-b-2 border-black border-solid first:text-white text-xl text-indigo-900 text-center leading-[50px]"
+              style={`background-color: ${itemArr[1]}`}
+            >
+              <span class="font-bold mr-2">{itemArr[0]}:</span>
               {itemArr[1]}
             </li>
           ))
@@ -29,20 +36,26 @@ import {colors, fontFamily} from '../../styles/themes/base'
       </ul>
     </div>
   </div>
-  <div class="w-11/12 m-auto mx-5">
-    <h2 class="text-center text-2xl">Typography</h2>
+  <div class="w-11/12 m-auto mt-5">
+    <h2 class="text-center text-3xl font-bold">Typography</h2>
     <div>
-      <h3 class="text-xl">Typography: Font Families</h3>
+      <h3 class="text-xl mb-1">
+        <span class="font-bold">Typography:</span> Font Families
+      </h3>
       <p>
-        These are the current font families available for use. Noto Sans is the default font for this site unless
-        otherwise stated.
+        These are the current font families available for use. Noto Sans is the default font for this site. Playfair was
+        added as an accent font.
       </p>
-      <ul>
+      <ul
+        class="mt-5 w-full flex flex-nowrap flex-col justify-center content-between border-2 border-black border-solid"
+      >
         {
           Object.entries(fontFamily).map(itemArr => (
-            <li>
-              <span class="font-bold">{itemArr[0]}:</span>
-              {itemArr[1]}
+            <li class="w-full h-[50px] [&:not(:last-child)]:border-b-2 border-black border-solid text-xl text-black text-center leading-[50px]">
+              <span class="font-bold mr-2" style={`font-family: ${itemArr[1].toString()}`}>
+                {itemArr[0]}:
+              </span>
+              {itemArr[1].toString()}
             </li>
           ))
         }

--- a/src/pages/styleguide/index.astro
+++ b/src/pages/styleguide/index.astro
@@ -1,37 +1,52 @@
 ---
 import {colors, fontFamily} from '../../styles/themes/base'
 ---
+
 <>
-    <div class="w-11/12 m-auto mb-5">
-        <h1 class="text-center text-4xl">The Astoria Tech Meetup Styleguide</h1>
-        <p class="text-center mt-2">A guide for contributors for element styling.  It is always evolving.</p>
+  <div class="w-11/12 m-auto mb-5">
+    <h1 class="text-center text-4xl">The Astoria Tech Meetup Styleguide</h1>
+    <p class="text-center mt-2">A guide for contributors for element styling. It is always evolving.</p>
+  </div>
+  <div class="w-11/12 m-auto mx-5">
+    <h2 class="text-center text-2xl">Theme Colors</h2>
+    <div>
+      <h3 class="text-xl">Themes: Default</h3>
+      <p>
+        The goal with theming is to have a set of standard colors that can be used in light or dark mode for any
+        element. Contributors should feel confident to add, modify, or delete themes when they want to change the look
+        of the site with ease. This theme is the default theme, which should be used as a starting point for any
+        additional themes.
+      </p>
+      <ul>
+        {
+          Object.entries(colors).map(itemArr => (
+            <li>
+              <span class="font-bold">{itemArr[0]}:</span>
+              {itemArr[1]}
+            </li>
+          ))
+        }
+      </ul>
     </div>
-    <div class="w-11/12 m-auto mx-5">
-        <h2 class="text-center text-2xl">Theme Colors</h2>
-        <div>
-            <h3 class="text-xl">Themes: Default</h3>
-            <p>The goal with theming is to have a set of standard colors that can be used in light or dark mode for any element. Contributors should feel confident to add, modify, or delete themes when they want to change the look of the site with ease. This theme is the default theme, which should be used as a starting point for any additional themes.</p>
-            <ul>
-                {Object.entries(colors).map(itemArr => (
-                    <li>
-                        <span class="font-bold">{itemArr[0]}:</span>{itemArr[1]}
-                    </li>
-                ))}
-            </ul>
-        </div>
+  </div>
+  <div class="w-11/12 m-auto mx-5">
+    <h2 class="text-center text-2xl">Typography</h2>
+    <div>
+      <h3 class="text-xl">Typography: Font Families</h3>
+      <p>
+        These are the current font families available for use. Noto Sans is the default font for this site unless
+        otherwise stated.
+      </p>
+      <ul>
+        {
+          Object.entries(fontFamily).map(itemArr => (
+            <li>
+              <span class="font-bold">{itemArr[0]}:</span>
+              {itemArr[1]}
+            </li>
+          ))
+        }
+      </ul>
     </div>
-    <div class="w-11/12 m-auto mx-5">
-        <h2 class="text-center text-2xl">Typography</h2>
-        <div>
-            <h3 class="text-xl">Typography: Font Families</h3>
-            <p>These are the current font families available for use.  Noto Sans is the default font for this site unless otherwise stated.</p>
-            <ul>
-                {Object.entries(fontFamily).map(itemArr => (
-                    <li>
-                        <span class="font-bold">{itemArr[0]}:</span>{itemArr[1]}
-                    </li>
-                ))}
-            </ul>
-        </div>
-    </div>
+  </div>
 </>

--- a/src/styles/themes/base.ts
+++ b/src/styles/themes/base.ts
@@ -34,7 +34,7 @@ export const colors = {
 
 export const fontFamily = {
   sans: ['NotoSans', 'Arial', 'Helvetica', 'sans-serif'],
-  'sans-bold': ['NotoSans-bold', 'Arial', 'Helvetica', 'sans-serif'],
+  sansBold: ['NotoSans-bold', 'Arial', 'Helvetica', 'sans-serif'],
   serif: ['PlayFair', 'Times New Roman', 'serif'],
-  'serif-bold': ['PlayFair-Bold', 'Times New Roman', 'serif'],
+  serifBold: ['PlayFair-Bold', 'Times New Roman', 'serif'],
 }


### PR DESCRIPTION
## Overview

This PR is the scaled down version of [ATM-65](https://github.com/astoria-tech/meetup/pull/93).  Please see the notes section for more details.

## Issue:

[ATM-65](https://github.com/astoria-tech/meetup/issues/65)

## Notes

This PR originally started out more ambitiously, which was great!  But also was perhaps getting a bit too far ahead of itself.

This PR instead:
- Creates a styleguide page that can be added to at any time
- Creates sections to show what swatches and font families are available
- Uses Tailwind OOTB, no modifying classes for now.

The reasoning behind this is to show what is available, but also leave room for iteration.  Those tickets should be forthcoming.

## Screenshots and Staging Environment

The Staging Environment is currently building, will update when available.

In the meantime, if pulling the branch and running locally, it looks like this (but larger):
<img width="974" alt="Screen Shot 2024-05-16 at 9 19 13 PM" src="https://github.com/astoria-tech/meetup/assets/3402228/9dbf646f-4763-423d-92f8-9cb5068e9112">

