### PR TITLE
refactor: update link colors for contrast

### DIFF
--- a/src/pages/styleguide/index.astro
+++ b/src/pages/styleguide/index.astro
@@ -25,10 +25,10 @@ import {colors, fontFamily} from '../../styles/themes/base'
         {
           Object.entries(colors).map(itemArr => (
             <li
-              class="w-full h-[50px] [&:not(:last-child)]:border-b-2 border-black border-solid first:text-white text-xl text-indigo-900 text-center leading-[50px]"
-              style={`background-color: ${itemArr[1]}`}
+              class="w-full h-[50px] [&:not(:last-child)]:border-b-2 border-black border-solid text-xl text-slate-200 text-center font-bold leading-[50px]"
+              style={`background-color: ${itemArr[1]}; -webkit-text-stroke: 1.25px #000000 `}
             >
-              <span class="font-bold mr-2">{itemArr[0]}:</span>
+              <span class="mr-2">{itemArr[0]}:</span>
               {itemArr[1]}
             </li>
           ))

--- a/src/styles/themes/config/themeVariables.ts
+++ b/src/styles/themes/config/themeVariables.ts
@@ -1,9 +1,9 @@
 //These color variables are the base for which theme variables can be assigned or referenced directly.
 
 export const linkPalette = {
-  base: '#4d86f7',
-  dark: '#3d6bc5',
-  light: '#709ef8',
+  base: '#0944BC',
+  dark: '#083CA7',
+  light: '#0A4CD1',
 }
 
 export const baseColors = {


### PR DESCRIPTION
## Overview
This PR changes the link colors for contrast as well as a minor fix for the styleguide.  See notes.

## Issue
[ATM-125](https://github.com/astoria-tech/meetup/issues/125)

## Notes
This PR changes the link colors to ones with a 7:1 contrast ratio or higher.  This works on the light or dark themed backgrounds.

Additionally, for readability on the styleguide, for colors, the text is now a white text with a black text stroke color.  See below for an example as well as the new link colors.

## Screenshot
<img width="296" alt="Screen Shot 2024-05-19 at 11 51 35 PM" src="https://github.com/astoria-tech/meetup/assets/3402228/30902885-b16c-4ba2-bc1f-b8e038f5eb0b">

